### PR TITLE
ART-3129:Fix label user story

### DIFF
--- a/.github/ISSUE_TEMPLATE/story_template.yml
+++ b/.github/ISSUE_TEMPLATE/story_template.yml
@@ -5,7 +5,7 @@
 name: "📝 User Story"
 description: Provide a detailed user story including what needs to be done, why, the tasks involved, and the acceptance criteria.
 title: "📝 USER STORY: "
-labels: ["user-story"]
+labels: ["user story"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
For the user story template, user-story label was used instead of the existing one user story.
This pr fixes that.